### PR TITLE
Adding client side redirect test and comments

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,15 +12,33 @@
     <script nomodule src="/build/shadowcat.js"></script>
   </head>
   <body>
+    <!-- Our typical oauth workflow using puma includes several server-side
+      redirects in order to get the auth token. This component tests a similar
+      workflow using the mock server. -->
     <manifold-oauth
-      id="oauth"
-      oauth-url="https://shadowcat-test-server.herokuapp.com/signin/oauth/web"
+      id="server-side"
+      oauth-url="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/web"
+    ></manifold-oauth>
+
+    <!-- Some platform-providers may want their oauth flow to include a
+      client-side redirect. This component tests that workflow using a different
+      endpoint on the mock server. -->
+    <manifold-oauth
+      id="client-side"
+      oauth-url="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/redirect"
     ></manifold-oauth>
 
     <script>
-      const oauth = document.getElementById("oauth");
-      oauth.addEventListener("tokenReceived", e => {
-        console.log(e.detail);
+      //These event listeners will be implemented as needed inside of our UI
+      //library and the resulting auth tokens are logged here for testing purposes.
+      const serverOauth = document.querySelector("#server-side");
+      serverOauth.addEventListener("tokenReceived", e => {
+        console.log("server-side: ", e.detail);
+      });
+
+      const clientOauth = document.querySelector("#client-side");
+      clientOauth.addEventListener("tokenReceived", e => {
+        console.log("client-side: ", e.detail);
       });
     </script>
   </body>


### PR DESCRIPTION
This provides some context for what our tests are doing. One question I have is if we want to include this in the published component library, or if that is risky because it requires the `manifold-shadowcat-test-server` to stay up on Heroku. 🤷‍♀ 