### PR TITLE
Broadcast the new token format and expose the types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "dist/index.mjs",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/interface.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/shadowcat/shadowcat.js",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/shadowcat/shadowcat.js",
   "files": [
-    "dist/",
-    "loader/"
+    "dist/"
   ],
   "scripts": {
     "build": "stencil build --docs",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -6,7 +6,9 @@
 
 
 import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
-
+import {
+  AuthToken,
+} from './interface';
 
 export namespace Components {
   interface ManifoldOauth {
@@ -30,7 +32,7 @@ declare global {
 declare namespace LocalJSX {
   interface ManifoldOauth extends JSXBase.HTMLAttributes<HTMLManifoldOauthElement> {
     'oauthUrl'?: string;
-    'onReceiveManifoldToken'?: (event: CustomEvent<any>) => void;
+    'onReceiveManifoldToken'?: (event: CustomEvent<AuthToken>) => void;
   }
 
   interface IntrinsicElements {

--- a/src/components/manifold-oauth/manifold-oauth.tsx
+++ b/src/components/manifold-oauth/manifold-oauth.tsx
@@ -1,14 +1,20 @@
 import { Event, EventEmitter, Component, h, Prop } from "@stencil/core";
+import { AuthToken, PumaAuthToken } from "../../interface";
 
 @Component({
   tag: "manifold-oauth"
 })
 export class ManifoldOauth {
   @Prop() oauthUrl?: string = "https://login.manifold.co/signin/oauth/web";
-  @Event() receiveManifoldToken: EventEmitter;
+  @Event() receiveManifoldToken: EventEmitter<AuthToken>;
 
   tokenListener = (ev: MessageEvent) => {
-    this.receiveManifoldToken.emit(ev.data);
+    const pumaToken = ev.data as PumaAuthToken;
+    this.receiveManifoldToken.emit({
+      token: pumaToken.access_token,
+      expiry: pumaToken.expiry,
+      error: pumaToken.error
+    });
   };
 
   componentWillLoad() {

--- a/src/components/manifold-oauth/readme.md
+++ b/src/components/manifold-oauth/readme.md
@@ -14,9 +14,9 @@
 
 ## Events
 
-| Event                  | Description | Type               |
-| ---------------------- | ----------- | ------------------ |
-| `receiveManifoldToken` |             | `CustomEvent<any>` |
+| Event                  | Description | Type                     |
+| ---------------------- | ----------- | ------------------------ |
+| `receiveManifoldToken` |             | `CustomEvent<AuthToken>` |
 
 
 ----------------------------------------------

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -1,0 +1,18 @@
+export * from "./components";
+
+export interface AuthError {
+  code: number;
+  message: string;
+}
+
+export interface AuthToken {
+  token?: string;
+  expiry?: string;
+  error?: AuthError;
+}
+
+export interface PumaAuthToken {
+  access_token?: string;
+  expiry?: string;
+  error?: AuthError;
+}


### PR DESCRIPTION
[See the test server changes](https://github.com/manifoldco/shadowcat-test-server/pull/3/files) for more context.

The server will broadcast a structured payload which can include an `access_token` and an `expiry`, or an `error`. The errors are currently strings, but will eventually be objects that have both a `code` and a `message`. 

We'll have `shadowcat` map this shape to the `AuthToken` type shown in this PR, so that we can use camelcased member names. We'll expose this type information to consumers of `shadowcat`.