### PR TITLE
Fix npm publish

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!-- *************************************** -->
+<!--       🌱 Pull Request Template          -->
+<!-- *************************************** -->
+
+<!-- ✅ Linked to ZenHub issue               -->
+
+## Reason for change
+
+<!-- What does this change, in plain language? -->
+<!-- Before/after screenshots may be helpful.  -->
+
+## Testing
+
+<!-- For someone unfamiliar with the issue, how should this be tested? -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - 12.4.0
 cache: npm
+before_install:
+  - echo "//registry.npmjs.org/:_authToken=$(npx @manifoldco/cli export -t manifold -p shadowcat-ci | grep NPM_TOKEN | cut -f2 -d "=")" >> ~/.npmrc
 stages:
   - test
   - publish
@@ -10,9 +12,12 @@ jobs:
     - stage: test
       name: "\U0001F5DC️ Run tests"
       script: npm run test:coverage
+    - stage: test
+      name: "📦 bundlesize"
+      script: npm run profile
     - stage: publish
-      name: Publish to npm
+      name: `🚀 Publish to npm'
       script: npm run publish
-      if: tag IS present
+      if: tag IS present AND branch = master
 after_success:
   - npx codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       name: "📦 bundlesize"
       script: npm run profile
     - stage: publish
-      name: `🚀 Publish to npm'
+      name: "🚀 Publish to npm"
       script: npm run publish
       if: tag IS present AND branch = master
 after_success:

--- a/package.json
+++ b/package.json
@@ -12,9 +12,27 @@
   "files": [
     "dist/"
   ],
+  "bundlesize": [
+    {
+      "path": "./dist/esm/loader.mjs",
+      "maxSize": "1 kB",
+      "compression": "none"
+    },
+    {
+      "path": "./dist/esm/manifold-!(mock)*.js",
+      "maxSize": "1 kB",
+      "compression": "none"
+    },
+    {
+      "path": "./dist/esm/chunk-*.js",
+      "maxSize": "40 kB",
+      "compression": "none"
+    }
+  ],
   "scripts": {
     "build": "stencil build --docs",
     "prepare": "stencil build",
+    "profile": "stencil build && npx bundlesize",
     "publish": "node scripts/publish",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "stencil build --docs",
+    "prepare": "stencil build",
     "publish": "node scripts/publish",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -21,7 +21,7 @@ const pkgDir = resolve(__dirname, "..", "pkg");
 if (!existsSync(pkgDir)) mkdirSync(pkgDir);
 emptyDirSync(pkgDir);
 copySync(oldDistDir, newDistDir);
-copySync(resolve(__dirname, "..", "readme.md"), resolve(pkgDir, "readme.md"));
+copySync(resolve(__dirname, "..", "README.md"), resolve(pkgDir, "README.md"));
 console.log(`[1/3] 🧹 Cleaning up…`);
 
 // 2. Read Git tag


### PR DESCRIPTION
![Screen Shot 2019-08-01 at 11 49 03](https://user-images.githubusercontent.com/1369770/62315391-75e87f80-b452-11e9-8d91-53c9a21681d4.png)

This fixes npm publishing in Shadowcat (hopefully). Was able to publish a test version locally (`0.1.2-test.0`)