### PR TITLE
Add missing keys to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,19 @@
 {
   "name": "@manifoldco/shadowcat",
   "description": "Invisible web component auth implementation of Manifold's PUMA",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manifoldco/shadowcat.git"
+  },
+  "homepage": "https://github.com/manifoldco/shadowcat",
+  "bugs": {
+    "url": "https://github.com/manifoldco/shadowcat/issues"
+  },
+  "engines": {
+    "node": ">=10.16.0"
+  },
+  "author": "manifoldco",
+  "license": "BSD",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "es2015": "dist/esm/index.mjs",
@@ -43,6 +56,5 @@
     "jest-cli": "24.8.0",
     "prettier": "^1.18.2",
     "puppeteer": "1.19.0"
-  },
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
## Reason for change
Suppresses warnings like “missing repository field” when installing @manifoldco/shadowcat from npm. Also corrects license.

## Testing

Minor change
