### PR TITLE
Sandbox the iframe to only allow scripts

### DIFF
--- a/src/components/manifold-oauth/manifold-oauth.e2e.ts
+++ b/src/components/manifold-oauth/manifold-oauth.e2e.ts
@@ -3,12 +3,18 @@ import { newE2EPage } from '@stencil/core/testing';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('my-component', () => {
-  it('renders', async () => {
+  it('is sandboxed to only allow scripts', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<manifold-oauth></manifold-oauth>');
-    const element = await page.find('manifold-oauth');
-    expect(element).toHaveClass('hydrated');
+    await page.waitForChanges();
+
+    const iframe = await page.find('iframe');
+    expect.assertions(1);
+    if (iframe) {
+      const sandbox = await iframe.getAttribute('sandbox');
+      expect(sandbox).toEqual('allow-scripts');
+    }
   });
 
   it('iframe keeps essential styling for Firefox', async () => {

--- a/src/components/manifold-oauth/manifold-oauth.tsx
+++ b/src/components/manifold-oauth/manifold-oauth.tsx
@@ -38,6 +38,7 @@ export class ManifoldOauth {
         name="manifold-oauth-window"
         scrolling="no"
         tabindex="-1"
+        sandbox="allow-scripts"
         style={{
           border: 'none', // don’t have a border
           display: 'block', // SUPER important for iframe to not be display: none

--- a/src/index.html
+++ b/src/index.html
@@ -8,8 +8,8 @@
     />
     <title>Stencil Component Starter</title>
 
-    <script type="module" src="/build/shadowcat.esm.js"></script>
-    <script nomodule src="/build/shadowcat.js"></script>
+    <script type="module" src="/build/manifold.esm.js"></script>
+    <script nomodule src="/build/manifold.js"></script>
   </head>
   <body>
     <!-- Our typical oauth workflow using puma includes several server-side
@@ -31,14 +31,14 @@
     <script>
       //These event listeners will be implemented as needed inside of our UI
       //library and the resulting auth tokens are logged here for testing purposes.
-      const serverOauth = document.querySelector("#server-side");
-      serverOauth.addEventListener("receiveManifoldToken", e => {
-        console.log("server-side: ", e.detail);
+      const serverOauth = document.querySelector('#server-side');
+      serverOauth.addEventListener('receiveManifoldToken', e => {
+        console.log('server-side: ', e.detail);
       });
 
-      const clientOauth = document.querySelector("#client-side");
-      clientOauth.addEventListener("receiveManifoldToken", e => {
-        console.log("client-side: ", e.detail);
+      const clientOauth = document.querySelector('#client-side');
+      clientOauth.addEventListener('receiveManifoldToken', e => {
+        console.log('client-side: ', e.detail);
       });
     </script>
   </body>


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

To maximize security, apply all sandbox restrictions except for scripts, which must be allowed.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

Tests should pass and the deploy preview should be printing success messages in the console.