### PR TITLE
Hardcode OAuth URL, add same-origin sandbox exemption

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,9 +11,7 @@ import {
 } from './interface';
 
 export namespace Components {
-  interface ManifoldOauth {
-    'oauthUrl'?: string;
-  }
+  interface ManifoldOauth {}
 }
 
 declare global {
@@ -31,7 +29,6 @@ declare global {
 
 declare namespace LocalJSX {
   interface ManifoldOauth extends JSXBase.HTMLAttributes<HTMLManifoldOauthElement> {
-    'oauthUrl'?: string;
     'onReceiveManifoldToken'?: (event: CustomEvent<AuthToken>) => void;
   }
 

--- a/src/components/manifold-oauth/manifold-oauth.e2e.ts
+++ b/src/components/manifold-oauth/manifold-oauth.e2e.ts
@@ -13,7 +13,7 @@ describe('my-component', () => {
     expect.assertions(1);
     if (iframe) {
       const sandbox = await iframe.getAttribute('sandbox');
-      expect(sandbox).toEqual('allow-scripts');
+      expect(sandbox).toEqual('allow-scripts allow-same-origin');
     }
   });
 

--- a/src/components/manifold-oauth/manifold-oauth.tsx
+++ b/src/components/manifold-oauth/manifold-oauth.tsx
@@ -1,21 +1,23 @@
-import { Event, EventEmitter, Component, h, Prop } from '@stencil/core';
+import { Event, EventEmitter, Component, h } from '@stencil/core';
 import { AuthToken, PumaAuthToken } from '../../interface';
 
 @Component({ tag: 'manifold-oauth' })
 export class ManifoldOauth {
-  @Prop() oauthUrl?: string = 'https://login.manifold.co/signin/oauth/web';
   @Event() receiveManifoldToken: EventEmitter<AuthToken>;
 
   private loadTime?: Date;
 
   tokenListener = (ev: MessageEvent) => {
     const pumaToken = ev.data as PumaAuthToken;
-    this.receiveManifoldToken.emit({
-      token: pumaToken.access_token,
-      expiry: pumaToken.expiry,
-      error: pumaToken.error,
-      duration: new Date().getTime() - this.loadTime.getTime(),
-    });
+
+    if (ev.origin === 'https://login.manifold.co') {
+      this.receiveManifoldToken.emit({
+        token: pumaToken.access_token,
+        expiry: pumaToken.expiry,
+        error: pumaToken.error,
+        duration: new Date().getTime() - this.loadTime.getTime(),
+      });
+    }
   };
 
   componentWillLoad() {
@@ -30,7 +32,7 @@ export class ManifoldOauth {
   render() {
     return (
       <iframe
-        src={this.oauthUrl}
+        src="https://login.manifold.co/signin/oauth/web"
         allowtransparency="true"
         aria-hidden="true"
         frameborder="0"
@@ -38,7 +40,7 @@ export class ManifoldOauth {
         name="manifold-oauth-window"
         scrolling="no"
         tabindex="-1"
-        sandbox="allow-scripts"
+        sandbox="allow-scripts allow-same-origin"
         style={{
           border: 'none', // don’t have a border
           display: 'block', // SUPER important for iframe to not be display: none

--- a/src/components/manifold-oauth/readme.md
+++ b/src/components/manifold-oauth/readme.md
@@ -5,13 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Properties
-
-| Property   | Attribute   | Description | Type     | Default                                        |
-| ---------- | ----------- | ----------- | -------- | ---------------------------------------------- |
-| `oauthUrl` | `oauth-url` |             | `string` | `'https://login.manifold.co/signin/oauth/web'` |
-
-
 ## Events
 
 | Event                  | Description | Type                     |

--- a/src/index.html
+++ b/src/index.html
@@ -12,33 +12,13 @@
     <script nomodule src="/build/manifold.js"></script>
   </head>
   <body>
-    <!-- Our typical oauth workflow using puma includes several server-side
-      redirects in order to get the auth token. This component tests a similar
-      workflow using the mock server. -->
-    <manifold-oauth
-      id="server-side"
-      oauth-url="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/web"
-    ></manifold-oauth>
-
-    <!-- Some platform-providers may want their oauth flow to include a
-      client-side redirect. This component tests that workflow using a different
-      endpoint on the mock server. -->
-    <manifold-oauth
-      id="client-side"
-      oauth-url="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/redirect"
-    ></manifold-oauth>
-
+    <manifold-oauth></manifold-oauth>
     <script>
       //These event listeners will be implemented as needed inside of our UI
       //library and the resulting auth tokens are logged here for testing purposes.
-      const serverOauth = document.querySelector('#server-side');
+      const serverOauth = document.querySelector('manifold-oauth');
       serverOauth.addEventListener('receiveManifoldToken', e => {
         console.log('server-side: ', e.detail);
-      });
-
-      const clientOauth = document.querySelector('#client-side');
-      clientOauth.addEventListener('receiveManifoldToken', e => {
-        console.log('client-side: ', e.detail);
       });
     </script>
   </body>


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

1. We shouldn't give consumers control over the OAuth URL
1. We should make sure that a message comes from PUMA before publishing data from that message
1. Our sandbox exemptions weren't sufficient, we need to `allow-same-origin` as well.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
The preview site should now raise a 401 when shadowcat tries to call to `/oauth/web`. The error should contain this message:

```
{"error":"domain deploy-preview-59--manifold-shadowcat.netlify.com is not allowed"}
```