### PR TITLE
Add tick prop for refreshing URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "./dist/esm/manifold*.js",
-      "maxSize": "2 kB",
+      "maxSize": "2.5 kB",
       "compression": "none"
     }
   ],

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,7 +11,9 @@ import {
 } from './interface';
 
 export namespace Components {
-  interface ManifoldOauth {}
+  interface ManifoldOauth {
+    'tick'?: string;
+  }
 }
 
 declare global {
@@ -30,6 +32,7 @@ declare global {
 declare namespace LocalJSX {
   interface ManifoldOauth extends JSXBase.HTMLAttributes<HTMLManifoldOauthElement> {
     'onReceiveManifoldToken'?: (event: CustomEvent<AuthToken>) => void;
+    'tick'?: string;
   }
 
   interface IntrinsicElements {

--- a/src/components/manifold-oauth/manifold-oauth.e2e.ts
+++ b/src/components/manifold-oauth/manifold-oauth.e2e.ts
@@ -2,50 +2,83 @@ import { newE2EPage } from '@stencil/core/testing';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-describe('my-component', () => {
-  it('is sandboxed to only allow scripts', async () => {
-    const page = await newE2EPage();
+describe('<manifold-oauth>', () => {
+  describe('security', () => {
+    it('iframe is URL-locked', async () => {
+      const page = await newE2EPage();
 
-    await page.setContent('<manifold-oauth></manifold-oauth>');
-    await page.waitForChanges();
+      await page.setContent('<manifold-oauth></manifold-oauth>');
+      await page.waitForChanges();
 
-    const iframe = await page.find('iframe');
-    expect.assertions(1);
-    if (iframe) {
+      const iframe = await page.find('iframe');
+      if (!iframe) {
+        throw new Error('iframe not in document');
+      }
+      const url = await iframe.getAttribute('src');
+      expect(url).toBe('https://login.manifold.co/signin/oauth/web');
+    });
+
+    it('iframe is sandboxed to only allow scripts', async () => {
+      const page = await newE2EPage();
+
+      await page.setContent('<manifold-oauth></manifold-oauth>');
+      await page.waitForChanges();
+
+      const iframe = await page.find('iframe');
+      if (!iframe) {
+        throw new Error('iframe not in document');
+      }
       const sandbox = await iframe.getAttribute('sandbox');
       expect(sandbox).toEqual('allow-scripts allow-same-origin');
-    }
+    });
   });
 
-  it('iframe keeps essential styling for Firefox', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<manifold-oauth></manifold-oauth>');
-    await page.waitForChanges();
-    const iframeStyling = await page.$eval('iframe', (elm: any) => ({
-      border: elm.style.border,
-      display: elm.style.display,
-      height: elm.style.height,
-      left: elm.style.left,
-      margin: elm.style.margin,
-      padding: elm.style.padding,
-      pointerEvents: elm.style.pointerEvents,
-      position: elm.style.position,
-      userSelect: elm.style.userSelect,
-      visibility: elm.style.visibility,
-      width: elm.style.width,
-    }));
-    expect(iframeStyling).toEqual({
-      border: 'none',
-      display: 'block',
-      height: '1px',
-      left: '0px',
-      margin: '0px',
-      padding: '0px',
-      pointerEvents: 'none',
-      position: 'fixed',
-      userSelect: 'none',
-      visibility: 'hidden',
-      width: '75vw',
+  describe('browser support', () => {
+    it('Firefox: iframe isn’t display: none, but still appears invisible to user', async () => {
+      const page = await newE2EPage();
+
+      await page.setContent('<manifold-oauth></manifold-oauth>');
+      await page.waitForChanges();
+      const iframeStyling = await page.$eval('iframe', (elm: any) => ({
+        attrs: {
+          allowTransparency: elm.getAttribute('allowtransparency'),
+          ariaHidden: elm.getAttribute('aria-hidden'),
+          frameborder: elm.getAttribute('frameborder'),
+          scrolling: elm.getAttribute('scrolling'),
+          tabindex: elm.getAttribute('tabindex'),
+        },
+        border: elm.style.border,
+        display: elm.style.display,
+        height: elm.style.height,
+        left: elm.style.left,
+        margin: elm.style.margin,
+        padding: elm.style.padding,
+        pointerEvents: elm.style.pointerEvents,
+        position: elm.style.position,
+        userSelect: elm.style.userSelect,
+        visibility: elm.style.visibility,
+        width: elm.style.width,
+      }));
+      expect(iframeStyling).toEqual({
+        attrs: {
+          allowTransparency: 'true',
+          ariaHidden: 'true',
+          frameborder: '0',
+          scrolling: 'no',
+          tabindex: '-1',
+        },
+        border: 'none',
+        display: 'block',
+        height: '1px',
+        left: '0px',
+        margin: '0px',
+        padding: '0px',
+        pointerEvents: 'none',
+        position: 'fixed',
+        userSelect: 'none',
+        visibility: 'hidden',
+        width: '75vw',
+      });
     });
   });
 });

--- a/src/components/manifold-oauth/manifold-oauth.spec.ts
+++ b/src/components/manifold-oauth/manifold-oauth.spec.ts
@@ -1,0 +1,27 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ManifoldOauth } from './manifold-oauth';
+
+describe('<manifold-oauth>', () => {
+  describe('v0 API', () => {
+    // Testing implementation details isn’t preferred, but E2E testing with
+    // page.on('request') proved to be too difficult with Stencil.
+    it('[tick]: when changed it resets iframe', async () => {
+      const page = await newSpecPage({
+        components: [ManifoldOauth],
+        html: '<manifold-oauth></manifold-oauth>',
+      });
+      const { root, rootInstance } = page;
+      if (!root || !rootInstance) {
+        throw new Error('manifold-oauth not in document');
+      }
+
+      const mockRefresh = jest.fn();
+      rootInstance.refreshIframe = mockRefresh;
+
+      expect(mockRefresh).not.toHaveBeenCalled();
+      rootInstance.tick = new Date().getTime();
+      await page.waitForChanges();
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/manifold-oauth/manifold-oauth.tsx
+++ b/src/components/manifold-oauth/manifold-oauth.tsx
@@ -40,9 +40,8 @@ export class ManifoldOauth {
   refreshIframe() {
     const iframe = this.el.querySelector('iframe');
     if (iframe) {
-      const src = iframe.getAttribute('src');
-      // set iframe to its own src to refresh. Works in Chrome, Firefox, and Safari.
-      iframe.setAttribute('src', src);
+      // set iframe src again to refresh. Works in Chrome, Firefox, and Safari.
+      iframe.setAttribute('src', OAUTH_URL);
     }
   }
 

--- a/src/components/manifold-oauth/manifold-oauth.tsx
+++ b/src/components/manifold-oauth/manifold-oauth.tsx
@@ -1,16 +1,24 @@
-import { Event, EventEmitter, Component, h } from '@stencil/core';
+import { h, Component, Element, Event, EventEmitter, Prop, Watch } from '@stencil/core';
 import { AuthToken, PumaAuthToken } from '../../interface';
+
+const OAUTH_ORIGIN = 'https://login.manifold.co';
+const OAUTH_URL = `${OAUTH_ORIGIN}/signin/oauth/web`;
 
 @Component({ tag: 'manifold-oauth' })
 export class ManifoldOauth {
+  @Element() el: HTMLElement;
+  @Prop() tick?: string;
   @Event() receiveManifoldToken: EventEmitter<AuthToken>;
+  @Watch('tick') keyChange() {
+    this.refreshIframe();
+  }
 
   private loadTime?: Date;
 
   tokenListener = (ev: MessageEvent) => {
     const pumaToken = ev.data as PumaAuthToken;
 
-    if (ev.origin === 'https://login.manifold.co') {
+    if (ev.origin === OAUTH_ORIGIN) {
       this.receiveManifoldToken.emit({
         token: pumaToken.access_token,
         expiry: pumaToken.expiry,
@@ -29,10 +37,19 @@ export class ManifoldOauth {
     window.removeEventListener('message', this.tokenListener);
   }
 
+  refreshIframe() {
+    const iframe = this.el.querySelector('iframe');
+    if (iframe) {
+      const src = iframe.getAttribute('src');
+      // set iframe to its own src to refresh. Works in Chrome, Firefox, and Safari.
+      iframe.setAttribute('src', src);
+    }
+  }
+
   render() {
     return (
       <iframe
-        src="https://login.manifold.co/signin/oauth/web"
+        src={OAUTH_URL}
         allowtransparency="true"
         aria-hidden="true"
         frameborder="0"

--- a/src/components/manifold-oauth/readme.md
+++ b/src/components/manifold-oauth/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type     | Default     |
+| -------- | --------- | ----------- | -------- | ----------- |
+| `tick`   | `tick`    |             | `string` | `undefined` |
+
+
 ## Events
 
 | Event                  | Description | Type                     |


### PR DESCRIPTION
## Reason for change

Adds a `tick` prop to `<manifold-oauth>` that, when changed, will reset the iframe `src` to request a new URL.

## Testing

Should be tested from within a platform

<!-- For someone unfamiliar with the issue, how should this be tested? -->
